### PR TITLE
Add methods to Enable/Disable AXP GPIO0 (power to microphone)

### DIFF
--- a/M5StickC-master/src/AXP192.cpp
+++ b/M5StickC-master/src/AXP192.cpp
@@ -523,6 +523,21 @@ void AXP192::SetLDO3(bool State)
     Write1Byte( 0x12 , buf );
 }
 
+void AXP192::SetGPIO0(bool State)
+{
+    uint8_t buf = Read8bit(0x90);
+    if ( State == true )
+    {
+        buf &= ~(0x07); // clear last 3 bits
+        buf |= 0x02;    // set as LDO
+    }
+    else
+    {
+        buf |= 0x07;    // set as floating
+    }
+    Write1Byte( 0x90 , buf );
+}
+
 // Not recommend to set charge current > 100mA, since Battery is only 80mAh.
 // more then 1C charge-rate may shorten battery life-span.
 void AXP192::SetChargeCurrent(uint8_t current)

--- a/M5StickC-master/src/AXP192.h
+++ b/M5StickC-master/src/AXP192.h
@@ -80,6 +80,7 @@ public:
     void SetCoulombClear()  __attribute__((deprecated)); // use ClearCoulombcounter instead
     void SetLDO2( bool State );     // Can turn LCD Backlight OFF for power saving
     void SetLDO3( bool State );
+    void SetGPIO0( bool State );
     void SetAdcState(bool State);
     
     // -- Power Off

--- a/alpha/alpha.ino
+++ b/alpha/alpha.ino
@@ -25,6 +25,8 @@ void setup() {
   }
 
   OT_ProtocolV2.begin();
+
+  TS_HAL.power_set_mic(false); // disable power to microphone
   
 }
 
@@ -85,18 +87,3 @@ void loop() {
 
   // TODO: call OT update_characteristic_cache at least once every 15 mins
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/alpha/hal.cpp
+++ b/alpha/hal.cpp
@@ -247,6 +247,21 @@ void _TS_HAL::reset()
   ESP.restart();
 }
 
+void _TS_HAL::power_set_mic(bool enabled) {
+  if (enabled) 
+  {
+#ifdef HAL_M5STICK_C
+  // GPIO0 low noise LDO
+  M5.Axp.SetGPIO0(true);
+#endif
+  } else 
+  {
+#ifdef HAL_M5STICK_C
+  // GPIO0 floating
+  M5.Axp.SetGPIO0(false);
+#endif
+  }
+}
 
 //
 // Common logging functions
@@ -272,4 +287,3 @@ void _TS_HAL::fail_reboot(const char *msg)
   delay(3000);
   reset();
 }
-

--- a/alpha/hal.h
+++ b/alpha/hal.h
@@ -119,6 +119,7 @@ class _TS_HAL
     void sleep(TS_SleepMode, uint32_t);
     void power_off();
     void reset();
+    void power_set_mic(bool);
 
     
     //


### PR DESCRIPTION
Implement methods that read and write to AXP to modify GPIO0 output. 
Tested on microphone demo code:
Calling `M5.Axp.SetGPIO0(false)` disables power to microphone.
Calling `M5.Axp.SetGPIO0(true)` enables power to microphone.

Attached table from datasheet for reference:
![image](https://user-images.githubusercontent.com/23294131/82121785-38c36300-97c2-11ea-8f5f-962cb48c2ca7.png)
