### PR TITLE
Poll A/B Buttons after interrupt 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.tmp
+.pio
+.vscode

--- a/alpha/hal.cpp
+++ b/alpha/hal.cpp
@@ -300,11 +300,6 @@ void _TS_HAL::led_set(TS_Led led, bool enable)
 #endif
 }
 
-TS_ButtonState btn_handle_gpio()
-{
-  return TS_ButtonState::Short;
-}
-
 TS_ButtonState btn_handle_power()
 {
   TS_ButtonState state = TS_ButtonState::Short;
@@ -332,8 +327,8 @@ TS_ButtonState btn_handle_power()
 
 void _TS_HAL::btn_init()
 {
-  this->buttonA = new TS_IOButton(BUTTONA, btn_handle_gpio);
-  this->buttonB = new TS_IOButton(BUTTONB, btn_handle_gpio);
+  this->buttonA = new TS_IOButton(BUTTONA, nullptr);
+  this->buttonB = new TS_IOButton(BUTTONB, nullptr);
   this->buttonP = new TS_IOButton(BUTTONP, btn_handle_power); 
 
   #ifdef HAL_M5STICK_C

--- a/alpha/io.cpp
+++ b/alpha/io.cpp
@@ -13,6 +13,29 @@ TS_IOButton::~TS_IOButton()
   detachInterrupt(PIN);
 }
 
+//
+// Public methods
+//
+
+TS_ButtonState TS_IOButton::get_state() 
+{
+  if (has_interrupt()) 
+  {
+    resolve_irq();
+  } 
+  
+  return poll();
+}
+
+bool TS_IOButton::has_interrupt()
+{
+  return irq;
+}
+
+//
+// Private methods
+//
+
 void TS_IOButton::isr() 
 {
   portENTER_CRITICAL_ISR(&mux);
@@ -20,23 +43,28 @@ void TS_IOButton::isr()
   portEXIT_CRITICAL_ISR(&mux);
 }
 
-TS_ButtonState TS_IOButton::get_state() 
+void TS_IOButton::resolve_irq()
 {
-  if (has_interrupt()) 
-  {
     portENTER_CRITICAL_ISR(&mux);
     irq = false;
     portEXIT_CRITICAL_ISR(&mux);
-    
+}
+
+TS_ButtonState TS_IOButton::poll()
+{
+  if (FUNC) 
+  {
     return FUNC();
   } 
   else 
   {
-    return TS_ButtonState::NotPressed;
+    if (digitalRead(PIN)) 
+    {
+      return TS_ButtonState::NotPressed;
+    } 
+    else 
+    {
+      return TS_ButtonState::Short;
+    }
   }
-}
-
-bool TS_IOButton::has_interrupt()
-{
-  return irq;
 }

--- a/alpha/io.h
+++ b/alpha/io.h
@@ -19,14 +19,20 @@ class TS_IOButton
     TS_IOButton(uint8_t reqPin, TS_ButtonState(*f)());
     ~TS_IOButton();
 
-    void IRAM_ATTR isr();
     TS_ButtonState get_state();
     bool has_interrupt();
-
+    
   private:
     const uint8_t PIN;
-    TS_ButtonState(*FUNC)();
     volatile bool irq;
+
+    void IRAM_ATTR isr();
+    void resolve_irq();
+    
+    TS_ButtonState(*FUNC)();
+    TS_ButtonState poll();
+    
+    
 };
 
 #endif

--- a/alpha/ui.cpp
+++ b/alpha/ui.cpp
@@ -189,30 +189,6 @@ void _TS_UI::task(void* parameter)
       }
     }
 
-    if (TS_HAL.btn_a_get() == TS_ButtonState::Short)
-    {
-      Serial.println("Button A pressed");
-    }
-
-    if (TS_HAL.btn_b_get() == TS_ButtonState::Short)
-    {
-      Serial.println("Button B pressed");
-    }
-
-    TS_ButtonState powerButtonState = TS_HAL.btn_power_get();
-    if (powerButtonState == TS_ButtonState::Short)
-    {
-      Serial.println("Power button short press");
-      TS_HAL.lcd_cursor(0, 0);
-      TS_HAL.lcd_printf("Power short");
-    }
-    else if (powerButtonState == TS_ButtonState::Long)
-    {
-      Serial.println("Power button long press");
-      TS_HAL.lcd_cursor(0, 0);
-      TS_HAL.lcd_printf("Power long");
-    }
-
     TS_HAL.sleep(TS_SleepMode::Task, 20);
   }
 }


### PR DESCRIPTION
The previous implementation sends button pressed whenever an interrupt was detected which caused errors when interrupts were wrongly detected.

Now for GPIO buttons A/B when interrupt is detected, a read is performed. Calling `TS_HAL.btn_*_get()` should be done as sparingly as possible. Can use `has_interrupt()` to check for interrupts.